### PR TITLE
modprobe lib80211_crypt_tkip on startup

### DIFF
--- a/work-folder/broadcom-wl-dkms.conf
+++ b/work-folder/broadcom-wl-dkms.conf
@@ -6,3 +6,4 @@ blacklist brcm80211
 blacklist brcmfmac
 blacklist brcmsmac
 blacklist bcma
+lib80211_crypt_tkip


### PR DESCRIPTION
This module is not pulled in automatically for encryption causing encryption (WPA2) to fail for me without this patch.